### PR TITLE
Fix Expired Slack Invite Link

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,9 +62,23 @@
 					<p class="lead text-center col-8">We are a student run club aimed at engaging students in cyber security. We represent UVU at local and national competitions, help students in their career path, and learn how to hack things together.</p>
 				</div>
 				<div class="row justify-content-center">
-					<a class="btn btn-primary btn-lg col-3" href="https://join.slack.com/t/uvucsc/shared_invite/enQtODk3ODg2MTY3MTI2LTA1NmZjMzBlMzU0Mzg1ZTlhNTgxYjY0YzQ0ODhkNzFmZjZkNGYyY2QwNTEzNjEyMTlhY2E1ZjZjZmUzMTQ4NGU" role="button"><ion-icon name="logo-slack"></ion-icon> &nbsp; Join Slack</a>
+					<a 
+						class="btn btn-primary btn-lg col-3"
+						href="https://join.slack.com/t/uvucsc/shared_invite/zt-n56x80ir-n74qzmxR24daCVlyMkJ~Zg"
+						role="button">
+						<ion-icon name="logo-slack"></ion-icon>
+						 &nbsp; Join Slack
+					</a>
+
 					<div class="col-1"></div>
-					<a class="btn btn-primary btn-lg col-3" href="http://eepurl.com/c5xLN5" role="button"><ion-icon name="mail"></ion-icon> &nbsp; Join Newsletter</a>
+
+					<a 
+						class="btn btn-primary btn-lg col-3"
+						href="http://eepurl.com/c5xLN5"
+						role="button">
+						<ion-icon name="mail"></ion-icon> 
+						&nbsp; Join Newsletter
+					</a>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
Remove expired Slack invite link and replace it with a non-expiring invite link.